### PR TITLE
fixed random otp (added limit for 6-digit output only)

### DIFF
--- a/src/main/java/in/mcxiv/disapp/PrototypeActivity.java
+++ b/src/main/java/in/mcxiv/disapp/PrototypeActivity.java
@@ -298,7 +298,11 @@ public class PrototypeActivity extends ListenerAdapter {
         event.getMessage().addReaction("\uD83D\uDC4D").queue();
 
         author.openPrivateChannel().queue(privateChannel -> {
-            int otp = (int) (Math.random() * 1000000);
+            /*int otp = (int) ((Math.random() * (999999 - 100000)) + 100000);
+            other method*/
+            Random random = new Random();
+            int otp = random.ints(100000, 999999).findFirst().getAsInt();
+            
             listOfOTPsSent.add(new MemberRecord(member, author, GUILD, otp));
             log.prt("Sending mail");
             sendVerificationMail(mail_id, otp);


### PR DESCRIPTION
The earlier code didn't have a lower limit, so the random numbers were starting from 0.
**Note**: Added a new random statement and also fixed the old one(but commented).